### PR TITLE
datetime format fix

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
       - name: Verify tag
         run: |
-          VERSION=$(grep '<Version>' Analytics-CSharp.csproj | sed "s@.*<Version>\(.*\)</Version>.*@\1@")
+          VERSION=$(grep '<Version>' Analytics-CSharp/Analytics-CSharp.csproj | sed "s@.*<Version>\(.*\)</Version>.*@\1@")
           if [ "${{ steps.vars.outputs.tag }}" != "$VERSION" ]; then {
             echo "Tag ${{ steps.vars.outputs.tag }} does not match the package version ($VERSION)"
             exit 1

--- a/Analytics-CSharp/Analytics-CSharp.csproj
+++ b/Analytics-CSharp/Analytics-CSharp.csproj
@@ -39,7 +39,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Coroutine.NET" Version="1.0.0" />
-    <PackageReference Include="Serialization.NET" Version="0.1.0" />
+    <PackageReference Include="Serialization.NET" Version="1.0.0" />
     <PackageReference Include="Sovran.NET" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Analytics-CSharp/Segment/Analytics/Plugins/ContextPlugin.cs
+++ b/Analytics-CSharp/Segment/Analytics/Plugins/ContextPlugin.cs
@@ -30,7 +30,7 @@ namespace Segment.Analytics.Plugins
 
         private void ApplyContextData(RawEvent @event)
         {
-            var context = new JsonObject(@event.context?.content)
+            var context = new JsonObject(@event.context?.Content)
             {
                 [LibraryKey] = _library
             };

--- a/Analytics-CSharp/Segment/Analytics/Utilities/EventsFileManager.cs
+++ b/Analytics-CSharp/Segment/Analytics/Utilities/EventsFileManager.cs
@@ -155,7 +155,7 @@ namespace Segment.Analytics.Utilities
             var file = CurrentFile();
             if (!file.Exists) return;
 
-            var contents = "],\"sentAt\":\"" + DateTime.UtcNow + "\",\"writeKey\":\"" + _writeKey + "\"}";
+            var contents = "],\"sentAt\":\"" + DateTime.UtcNow.ToString("o") + "\",\"writeKey\":\"" + _writeKey + "\"}";
             await WriteToFile(contents.GetBytes(), file);
             _fs.Close();
 

--- a/Analytics-CSharp/Segment/Analytics/Version.cs
+++ b/Analytics-CSharp/Segment/Analytics/Version.cs
@@ -2,6 +2,6 @@ namespace Segment.Analytics
 {
     internal static class Version
     {
-        internal const string SegmentVersion = "1.2.4";
+        internal const string SegmentVersion = "1.0.2";
     }
 }

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,7 @@
 Update Version
 ==========
 * update `<Version>` value in `Analytics-CSharp.csproj`
+* update `SegmentVersion` value in `Segment/Analytics/Version.cs`
 
 Release to Nuget
 ==========

--- a/Tests/EventsTest.cs
+++ b/Tests/EventsTest.cs
@@ -72,7 +72,7 @@ namespace Tests
             _analytics.Track(expectedEvent);
             
             Assert.NotEmpty(actual);
-            Assert.True(actual[0].properties.count == 0);
+            Assert.True(actual[0].properties.Count == 0);
             Assert.Equal(expectedEvent, actual[0].@event);
         }
         
@@ -103,7 +103,7 @@ namespace Tests
             _analytics.Track<FooBar>(expectedEvent);
             
             Assert.NotEmpty(actual);
-            Assert.True(actual[0].properties.count == 0);
+            Assert.True(actual[0].properties.Count == 0);
             Assert.Equal(expectedEvent, actual[0].@event);
         }
 
@@ -139,7 +139,7 @@ namespace Tests
             var actualUserId = await _analytics.UserIdAsync();
             
             Assert.NotEmpty(actual);
-            Assert.True(actual[0].traits.count == 0);
+            Assert.True(actual[0].traits.Count == 0);
             Assert.Equal(expectedUserId, actualUserId);
         }
         
@@ -192,7 +192,7 @@ namespace Tests
             var actualUserId = await _analytics.UserIdAsync();
             
             Assert.NotEmpty(actual);
-            Assert.True(actual[0].traits.count == 0);
+            Assert.True(actual[0].traits.Count == 0);
             Assert.Equal(expectedUserId, actualUserId);
         }
         
@@ -244,7 +244,7 @@ namespace Tests
             _analytics.Screen(null, null, null);
             
             Assert.NotEmpty(actual);
-            Assert.True(actual[0].properties.count == 0);
+            Assert.True(actual[0].properties.Count == 0);
             Assert.Null(actual[0].name);
             Assert.Null(actual[0].category);
         }
@@ -277,7 +277,7 @@ namespace Tests
             _analytics.Screen<FooBar>(null, null, null);
             
             Assert.NotEmpty(actual);
-            Assert.True(actual[0].properties.count == 0);
+            Assert.True(actual[0].properties.Count == 0);
             Assert.Null(actual[0].name);
             Assert.Null(actual[0].category);
         }
@@ -312,7 +312,7 @@ namespace Tests
             _analytics.Group(expectedGroupId);
             
             Assert.NotEmpty(actual);
-            Assert.True(actual[0].traits.count == 0);
+            Assert.True(actual[0].traits.Count == 0);
             Assert.Equal(expectedGroupId, actual[0].groupId);
         }
         
@@ -343,7 +343,7 @@ namespace Tests
             _analytics.Group<FooBar>(expectedGroupId);
             
             Assert.NotEmpty(actual);
-            Assert.True(actual[0].traits.count == 0);
+            Assert.True(actual[0].traits.Count == 0);
             Assert.Equal(expectedGroupId, actual[0].groupId);
         }
 


### PR DESCRIPTION
* fix the issue that newston json converts string in datetime pattern to a different format
* fix the issue that the value of `sentAt` is in the wrong datetime format. it is now iso8601