### PR TITLE
fix concurrent collection modification issue

### DIFF
--- a/Analytics-CSharp/Analytics-CSharp.csproj
+++ b/Analytics-CSharp/Analytics-CSharp.csproj
@@ -39,7 +39,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Coroutine.NET" Version="1.3.0" />
-    <PackageReference Include="Serialization.NET" Version="1.3.0" />
+    <PackageReference Include="Serialization.NET" Version="1.4.0" />
     <PackageReference Include="Sovran.NET" Version="1.3.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Analytics-CSharp/Segment/Analytics/Configuration.cs
+++ b/Analytics-CSharp/Segment/Analytics/Configuration.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using Segment.Analytics.Policies;
 using Segment.Analytics.Utilities;
 using Segment.Concurrent;
+using Segment.Serialization;
 
 namespace Segment.Analytics
 {
@@ -94,7 +95,7 @@ namespace Segment.Analytics
             AnalyticsErrorHandler = analyticsErrorHandler;
             StorageProvider = storageProvider ?? new DefaultStorageProvider();
             HttpClientProvider = httpClientProvider ?? new DefaultHTTPClientProvider();
-            FlushPolicies = flushPolicies ?? new List<IFlushPolicy>();
+            FlushPolicies = flushPolicies == null ? new ConcurrentList<IFlushPolicy>() : new ConcurrentList<IFlushPolicy>(flushPolicies);
             if (FlushPolicies.Count == 0)
             {
                 FlushPolicies.Add(new CountFlushPolicy(flushAt));

--- a/Analytics-CSharp/Segment/Analytics/Timeline.cs
+++ b/Analytics-CSharp/Segment/Analytics/Timeline.cs
@@ -1,3 +1,4 @@
+using System.Collections.Concurrent;
 using System.Reflection;
 using global::System;
 using global::System.Collections.Generic;
@@ -12,15 +13,15 @@ namespace Segment.Analytics
     /// </summary>
     public class Timeline
     {
-        internal Dictionary<PluginType, Mediator> _plugins;
+        internal IDictionary<PluginType, Mediator> _plugins;
 
-        public Timeline() => _plugins = new Dictionary<PluginType, Mediator>()
+        public Timeline() => _plugins = new ConcurrentDictionary<PluginType, Mediator>
             {
-                { PluginType.Before, new Mediator() },
-                { PluginType.Enrichment, new Mediator() },
-                { PluginType.Destination, new Mediator() },
-                { PluginType.After, new Mediator() },
-                { PluginType.Utility, new Mediator() }
+                [PluginType.Before] = new Mediator(),
+                [PluginType.Enrichment] = new Mediator(),
+                [PluginType.Destination] = new Mediator(),
+                [PluginType.After] = new Mediator(),
+                [PluginType.Utility] = new Mediator()
             };
 
         /// <summary>

--- a/Analytics-CSharp/Segment/Analytics/Utilities/UserPrefs.cs
+++ b/Analytics-CSharp/Segment/Analytics/Utilities/UserPrefs.cs
@@ -620,7 +620,6 @@ namespace Segment.Analytics.Utilities
                             if (!copyToDisk.ContainsKey(k))
                             {
                                 continue;
-                                ;
                             }
 
                             copyToDisk.Remove(k);

--- a/Samples/UnitySample/LifecyclePlugin.cs
+++ b/Samples/UnitySample/LifecyclePlugin.cs
@@ -56,7 +56,9 @@ namespace UnitySample
     /// </summary>
     public class Lifecycle : Singleton<Lifecycle>, IObservable<Lifecycle.State>
     {
-        private readonly List<IObserver<State>> _observers = new List<IObserver<State>>();
+        // use Segment's ConcurrentList to avoid modification during enumeration
+        // or you have to make a copy for iterating the observers.
+        private readonly IList<IObserver<State>> _observers = new ConcurrentList<IObserver<State>>();
 
         private const string AppVersionKey = "app_version";
 
@@ -122,10 +124,10 @@ namespace UnitySample
 
         private class Unsubscriber : IDisposable
         {
-            private List<IObserver<State>> _observers;
+            private IList<IObserver<State>> _observers;
             private IObserver<State> _observer;
 
-            public Unsubscriber(List<IObserver<State>> observers, IObserver<State> observer)
+            public Unsubscriber(IList<IObserver<State>> observers, IObserver<State> observer)
             {
                 _observers = observers;
                 _observer = observer;

--- a/Samples/UnitySample/UnitySample.csproj
+++ b/Samples/UnitySample/UnitySample.csproj
@@ -33,10 +33,10 @@
     </PropertyGroup>
     <ItemGroup>
         <Reference Include="Coroutine.NET, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
-          <HintPath>..\..\packages\Coroutine.NET.1.1.0\lib\netstandard2.0\Coroutine.NET.dll</HintPath>
+          <HintPath>..\..\packages\Coroutine.NET.1.3.0\lib\netstandard2.0\Coroutine.NET.dll</HintPath>
         </Reference>
         <Reference Include="Serialization.NET">
-          <HintPath>..\..\..\..\.nuget\packages\serialization.net\1.2.0\lib\netstandard2.0\Serialization.NET.dll</HintPath>
+          <HintPath>..\..\..\..\.nuget\packages\serialization.net\1.4.0\lib\netstandard2.0\Serialization.NET.dll</HintPath>
         </Reference>
         <Reference Include="System" />
         <Reference Include="System.Core" />
@@ -59,7 +59,7 @@
       </ProjectReference>
     </ItemGroup>
     <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-    <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+    <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
          Other similar extension points exist, see Microsoft.Common.targets.
     <Target Name="BeforeBuild">
     </Target>


### PR DESCRIPTION
attempt to address issue mentioned in #61 caused by concurrent access of collection (dictionary and list)
* replace `Dictionary` with `ConcurrentDictionary`
* replace `List` with `ConcurrentList`
* update Serialization.NET to latest that makes JsonObject and JsonArray thread safe while enumerating
* update Unity LifecyclePlugin sample to use `ConcurrentList` to be thread safe on read. 