### PR TITLE
fix: use apiHost value to create http client in event pipeline

### DIFF
--- a/Analytics-CSharp/Segment/Analytics/Utilities/EventPipeline.cs
+++ b/Analytics-CSharp/Segment/Analytics/Utilities/EventPipeline.cs
@@ -47,7 +47,7 @@ namespace Segment.Analytics.Utilities
 
             _writeChannel = new Channel<RawEvent>();
             _uploadChannel = new Channel<string>();
-            _httpClient = analytics.Configuration.HttpClientProvider.CreateHTTPClient(apiKey);
+            _httpClient = analytics.Configuration.HttpClientProvider.CreateHTTPClient(apiKey, apiHost: apiHost);
             _httpClient.AnalyticsRef = analytics;
             _storage = analytics.Storage;
             Running = false;

--- a/Analytics-CSharp/Segment/Analytics/Version.cs
+++ b/Analytics-CSharp/Segment/Analytics/Version.cs
@@ -2,6 +2,6 @@ namespace Segment.Analytics
 {
     internal static class Version
     {
-        internal const string SegmentVersion = "2.3.1";
+        internal const string SegmentVersion = "2.3.2";
     }
 }


### PR DESCRIPTION
Make sure the apiHost argument is used when creating the HTTP Client. 

Discussion topic: Is there any purpose to having `internal string ApiHost { get; set; }` at all? The code in SegmentDestination.cs is updating the value but it will not have any effect since the HTTP client has already been created with the initial `apiHost` value.