### PR TITLE
Feature - Add methods to make flush synchronously

### DIFF
--- a/Analytics-CSharp/Segment/Analytics/Analytics.cs
+++ b/Analytics-CSharp/Segment/Analytics/Analytics.cs
@@ -134,6 +134,19 @@ namespace Segment.Analytics
             }
         });
 
+        public virtual bool FlushSync()
+        {
+            bool finished = false;
+            Apply(plugin =>
+            {
+                if (plugin is EventPlugin eventPlugin)
+                {
+                    finished = eventPlugin.FlushSync();
+                }
+            });
+            return finished;
+        }
+
 
         /// <summary>
         /// Reset the user identity info and all the event plugins. Should be invoked when

--- a/Analytics-CSharp/Segment/Analytics/Configuration.cs
+++ b/Analytics-CSharp/Segment/Analytics/Configuration.cs
@@ -25,6 +25,8 @@ namespace Segment.Analytics
 
         public bool UseSynchronizeDispatcher { get; }
 
+        public bool SynchroniceFlush { get; }
+
         [Obsolete("Please use AnalyticsErrorHandler instead")]
         public ICoroutineExceptionHandler ExceptionHandler {
             get
@@ -123,6 +125,31 @@ namespace Segment.Analytics
                 storageProvider,
                 httpClientProvider)
         {
+
+        }
+
+        public Configuration(string writeKey,
+            Settings defaultSettings = new Settings(),
+            bool autoAddSegmentDestination = true,
+            bool synchroniceFlush = false,
+            bool useSynchronizeDispatcher = false,
+            string apiHost = null,
+            string cdnHost = null,
+            IAnalyticsErrorHandler analyticsErrorHandler = null,
+            IStorageProvider storageProvider = default,
+            IHTTPClientProvider httpClientProvider = default)
+        {
+            WriteKey = writeKey;
+            DefaultSettings = defaultSettings;
+            AutoAddSegmentDestination = autoAddSegmentDestination;
+            UseSynchronizeDispatcher = useSynchronizeDispatcher;
+            ApiHost = apiHost;
+            CdnHost = cdnHost;
+            AnalyticsErrorHandler = analyticsErrorHandler;
+            StorageProvider = storageProvider ?? new DefaultStorageProvider();
+            HttpClientProvider = httpClientProvider ?? new DefaultHTTPClientProvider();
+            SynchroniceFlush = synchroniceFlush;
+
 
         }
     }

--- a/Analytics-CSharp/Segment/Analytics/Plugins.cs
+++ b/Analytics-CSharp/Segment/Analytics/Plugins.cs
@@ -63,6 +63,8 @@ namespace Segment.Analytics
 
         public virtual void Flush() { }
 
+        public virtual bool FlushSync() => true;
+
         public override RawEvent Execute(RawEvent incomingEvent)
         {
             switch (incomingEvent)

--- a/Analytics-CSharp/Segment/Analytics/Plugins/SegmentDestination.cs
+++ b/Analytics-CSharp/Segment/Analytics/Plugins/SegmentDestination.cs
@@ -1,3 +1,4 @@
+using System;
 using Segment.Analytics.Utilities;
 using Segment.Serialization;
 using Segment.Sovran;
@@ -69,7 +70,8 @@ namespace Segment.Analytics.Plugins
                     Key,
                     analytics.Configuration.WriteKey,
                     analytics.Configuration.FlushPolicies,
-                    analytics.Configuration.ApiHost
+                    analytics.Configuration.ApiHost,
+                    analytics.Configuration.SynchroniceFlush
                 );
 
             analytics.AnalyticsScope.Launch(analytics.AnalyticsDispatcher, async () =>
@@ -96,6 +98,8 @@ namespace Segment.Analytics.Plugins
         }
 
         public override void Flush() => _pipeline?.Flush();
+
+        public override bool FlushSync() => (bool)_pipeline?.FlushSync();
 
         private void Enqueue<T>(T payload) where T : RawEvent
         {

--- a/Samples/AspNetMvcSample/Startup.cs
+++ b/Samples/AspNetMvcSample/Startup.cs
@@ -9,7 +9,9 @@ using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Segment.Analytics;
+using Segment.Analytics.Policies;
 using Segment.Analytics.Utilities;
+using Segment.Serialization;
 
 namespace AspNetMvcSample
 {
@@ -26,10 +28,13 @@ namespace AspNetMvcSample
         public void ConfigureServices(IServiceCollection services)
         {
             // use `InMemoryStorageProvider` to make Analytics stateless
-            var configuration = new Configuration("YOUR WRITE KEY",
+            var configuration = new Configuration("DDGmj3fYhaFjvObdg3IBm0pvyq5kdZpD",
                 flushAt: 1,
-                flushInterval: 10,
-                storageProvider: new InMemoryStorageProvider());
+                flushInterval: 50,
+                storageProvider: new InMemoryStorageProvider()
+                //synchroniceFlush: true
+                //useSynchronizeDispatcher: true
+                );
 
             services.AddControllersWithViews();
             services.AddScoped(_ => new Analytics(configuration));


### PR DESCRIPTION
The main idea is adding a property `synchroniceFlush` and a new constructor for `Configuration` class to define when the process will execute async or sync process.

**Help to solve an issue**

I have an issue on flow because I can't fill the queue with all the events before the make the flush, the methods involved are `WriteSync` and `UploadSync` on `EventPipeline` class.

*NOTE: this is my solution if exist a better option to implement I can work on that suggestion.*