### PR TITLE
fix settings update method not called with await

### DIFF
--- a/Analytics-CSharp/Segment/Analytics/Settings.cs
+++ b/Analytics-CSharp/Segment/Analytics/Settings.cs
@@ -16,7 +16,7 @@ namespace Segment.Analytics
 
     public partial class Analytics
     {
-        internal async void Update(Settings settings) {
+        internal async Task Update(Settings settings) {
             System systemState = await Store.CurrentState<System>();
             HashSet<int> initializedPlugins = new HashSet<int>();
             Timeline.Apply(plugin => {
@@ -49,7 +49,7 @@ namespace Segment.Analytics
                 settings = systemState._settings;
             }
 
-            Update(settings.Value);
+            await Update(settings.Value);
             await Store.Dispatch<System.ToggleRunningAction, System>(new System.ToggleRunningAction(true));
         }
     }


### PR DESCRIPTION
* fix the issue mentioned in #89 
* manually tested the state dispatched to startup queue are no in sync. previously the `Update` method dispatches state after its successor.