### PR TITLE
NullReferenceException when fetching System state

### DIFF
--- a/Analytics-CSharp/Segment/Analytics/Analytics.cs
+++ b/Analytics-CSharp/Segment/Analytics/Analytics.cs
@@ -191,6 +191,10 @@ namespace Segment.Analytics
         {
             Settings? returnSettings = null;
             IState system = await Store.CurrentState<System>();
+
+            // I don't understand this as Store.CurrentState will at worst return a default(TState) which will be a default(System) in this case, hence this cast will always go through?
+            // System is a struct, so the default is an empty instance, not null
+            // might as well write /* if (true) */
             if (system is System convertedSystem)
             {
                 returnSettings = convertedSystem._settings;

--- a/Analytics-CSharp/Segment/Analytics/Timeline.cs
+++ b/Analytics-CSharp/Segment/Analytics/Timeline.cs
@@ -161,10 +161,18 @@ namespace Segment.Analytics
             analytics.AnalyticsScope.Launch(analytics.AnalyticsDispatcher, async () =>
             {
                 Settings? settings = await plugin.Analytics.SettingsAsync();
+
+                // This is basically never null, look at the comment in SettingsAsync
+                if (settings == null)
+                {
+                    return;
+                }
+
+                // Fetch system afterwards for a minuscule but cool performance gain
                 System system = await analytics.Store.CurrentState<System>();
-                // Don't initialize unless we have updated settings from the web.
-                // CheckSettings will initialize everything added before then, so wait until other inits have happened.
-                if (settings.HasValue && system._initializedPlugins.Count > 0)
+
+                // Check for nullability because CurrentState returns default(IState) which could make the .Count throw a NullReferenceException
+                if (system._initializedPlugins != null && system._initializedPlugins.Count > 0)
                 {
                     await analytics.Store.Dispatch<System.AddInitializedPluginAction, System>(new System.AddInitializedPluginAction(new HashSet<int>{plugin.GetHashCode()}));
                     plugin.Update(settings.Value, UpdateType.Initial);


### PR DESCRIPTION
Uhhh, will probably remove the comments. But there are some valid concerns in the code.
My main question is: do you realize that returning a default of a struct is not a null value, but rather an empty instance?

TLDR: NullReferenceException in #97 is caused by an uninitialized HashSet.