### PR TITLE
support enrichment closure and setAnonymousId

### DIFF
--- a/Analytics-CSharp/Segment/Analytics/Analytics.cs
+++ b/Analytics-CSharp/Segment/Analytics/Analytics.cs
@@ -101,6 +101,19 @@ namespace Segment.Analytics
         /// <returns>Anonymous Id</returns>
         public virtual string AnonymousId() => _userInfo._anonymousId;
 
+        /// <summary>
+        /// Set the anonymousId.
+        /// </summary>
+        /// <param name="anonymousId">Anonymous Id</param>
+        public virtual void SetAnonymousId(string anonymousId)
+        {
+            _userInfo._anonymousId = anonymousId;
+            AnalyticsScope.Launch(AnalyticsDispatcher, async () =>
+            {
+                await Store.Dispatch<UserInfo.SetAnonymousIdAction, UserInfo>(new UserInfo.SetAnonymousIdAction(anonymousId));
+            });
+        }
+
 
         /// <summary>
         /// Retrieve the userId registered by a previous <see cref="Identify(string,JsonObject)"/> call

--- a/Analytics-CSharp/Segment/Analytics/Analytics.cs
+++ b/Analytics-CSharp/Segment/Analytics/Analytics.cs
@@ -81,14 +81,15 @@ namespace Segment.Analytics
         /// Process a raw event through the system. Useful when one needs to queue and replay events at a later time.
         /// </summary>
         /// <param name="incomingEvent">An event conforming to RawEvent to be processed in the timeline</param>
-        public void Process(RawEvent incomingEvent)
+        /// <param name="enrichment">a closure that enables enrichment on the generated event</param>
+        public void Process(RawEvent incomingEvent, Func<RawEvent, RawEvent> enrichment = default)
         {
             if (!Enable) return;
 
             incomingEvent.ApplyRawEventData(_userInfo);
             AnalyticsScope.Launch(AnalyticsDispatcher, () =>
             {
-                Timeline.Process(incomingEvent);
+                Timeline.Process(incomingEvent, enrichment);
             });
         }
 

--- a/Analytics-CSharp/Segment/Analytics/Events.cs
+++ b/Analytics-CSharp/Segment/Analytics/Events.cs
@@ -1,3 +1,4 @@
+using System;
 using global::System.Runtime.Serialization;
 using Segment.Serialization;
 
@@ -12,7 +13,8 @@ namespace Segment.Analytics
         /// </summary>
         /// <param name="name">Name of the action</param>
         /// <param name="properties">Properties to describe the action</param>
-        public virtual void Track(string name, JsonObject properties = default)
+        /// <param name="enrichment">a closure that enables enrichment on the generated event</param>
+        public virtual void Track(string name, JsonObject properties = default, Func<RawEvent, RawEvent> enrichment = default)
         {
             if (properties == null)
             {
@@ -20,7 +22,7 @@ namespace Segment.Analytics
             }
 
             var trackEvent = new TrackEvent(name, properties);
-            Process(trackEvent);
+            Process(trackEvent, enrichment);
         }
 
         /// <summary>
@@ -30,17 +32,18 @@ namespace Segment.Analytics
         /// </summary>
         /// <param name="name">Name of the action</param>
         /// <param name="properties">Properties to describe the action</param>
+        /// <param name="enrichment">a closure that enables enrichment on the generated event</param>
         /// <typeparam name="T">Type that implements <see cref="ISerializable"/></typeparam>
-        public virtual void Track<T>(string name, T properties = default) where T : ISerializable
+        public virtual void Track<T>(string name, T properties = default, Func<RawEvent, RawEvent> enrichment = default) where T : ISerializable
         {
             if (properties == null)
             {
-                Track(name);
+                Track(name, enrichment: enrichment);
             }
             else
             {
                 string json = JsonUtility.ToJson(properties);
-                Track(name, JsonUtility.FromJson<JsonObject>(json));
+                Track(name, JsonUtility.FromJson<JsonObject>(json), enrichment);
             }
         }
 
@@ -59,7 +62,8 @@ namespace Segment.Analytics
         /// </summary>
         /// <param name="userId">Unique identifier which you recognize a user by in your own database</param>
         /// <param name="traits">Traits about the user</param>
-        public virtual void Identify(string userId, JsonObject traits = default)
+        /// <param name="enrichment">a closure that enables enrichment on the generated event</param>
+        public virtual void Identify(string userId, JsonObject traits = default, Func<RawEvent, RawEvent> enrichment = default)
         {
             if (traits == null)
             {
@@ -76,7 +80,7 @@ namespace Segment.Analytics
             });
 
             var identifyEvent = new IdentifyEvent(userId, traits);
-            Process(identifyEvent);
+            Process(identifyEvent, enrichment);
         }
 
         /// <summary>
@@ -93,7 +97,8 @@ namespace Segment.Analytics
         /// info.
         /// </summary>
         /// <param name="traits">Traits about the user</param>
-        public virtual void Identify(JsonObject traits)
+        /// <param name="enrichment">a closure that enables enrichment on the generated event</param>
+        public virtual void Identify(JsonObject traits, Func<RawEvent, RawEvent> enrichment = default)
         {
             if (traits == null)
             {
@@ -109,7 +114,7 @@ namespace Segment.Analytics
             });
 
             var identifyEvent = new IdentifyEvent(_userInfo._userId, traits);
-            Process(identifyEvent);
+            Process(identifyEvent, enrichment);
         }
 
         /// <summary>
@@ -127,17 +132,18 @@ namespace Segment.Analytics
         /// </summary>
         /// <param name="userId">Unique identifier which you recognize a user by in your own database</param>
         /// <param name="traits">Traits about the user</param>
+        /// <param name="enrichment">a closure that enables enrichment on the generated event</param>
         /// <typeparam name="T">Type that implements <see cref="ISerializable"/></typeparam>
-        public virtual void Identify<T>(string userId, T traits = default) where T : ISerializable
+        public virtual void Identify<T>(string userId, T traits = default, Func<RawEvent, RawEvent> enrichment = default) where T : ISerializable
         {
             if (traits == null)
             {
-                Identify(userId);
+                Identify(userId, enrichment: enrichment);
             }
             else
             {
                 string json = JsonUtility.ToJson(traits);
-                Identify(userId, JsonUtility.FromJson<JsonObject>(json));
+                Identify(userId, JsonUtility.FromJson<JsonObject>(json), enrichment);
             }
         }
 
@@ -155,17 +161,18 @@ namespace Segment.Analytics
         /// info.
         /// </summary>
         /// <param name="traits">Traits about the user</param>
+        /// <param name="enrichment">a closure that enables enrichment on the generated event</param>
         /// <typeparam name="T">Type that implements <see cref="ISerializable"/></typeparam>
-        public virtual void Identify<T>(T traits) where T : ISerializable
+        public virtual void Identify<T>(T traits, Func<RawEvent, RawEvent> enrichment = default) where T : ISerializable
         {
             if (traits == null)
             {
-                Identify(new JsonObject());
+                Identify(new JsonObject(), enrichment);
             }
             else
             {
                 string json = JsonUtility.ToJson(traits);
-                Identify(JsonUtility.FromJson<JsonObject>(json));
+                Identify(JsonUtility.FromJson<JsonObject>(json), enrichment);
             }
         }
 
@@ -177,14 +184,15 @@ namespace Segment.Analytics
         /// <param name="title">A name for the screen</param>
         /// <param name="properties">Properties to add extra information to this call</param>
         /// <param name="category">A category to describe the screen</param>
-        public virtual void Screen(string title, JsonObject properties = default, string category = "")
+        /// <param name="enrichment">a closure that enables enrichment on the generated event</param>
+        public virtual void Screen(string title, JsonObject properties = default, string category = "", Func<RawEvent, RawEvent> enrichment = default)
         {
             if (properties == null)
             {
                 properties = new JsonObject();
             }
             var screenEvent = new ScreenEvent(category, title, properties);
-            Process(screenEvent);
+            Process(screenEvent, enrichment);
         }
 
         /// <summary>
@@ -195,17 +203,18 @@ namespace Segment.Analytics
         /// <param name="title">A name for the screen</param>
         /// <param name="properties">Properties to add extra information to this call</param>
         /// <param name="category">A category to describe the screen</param>
+        /// <param name="enrichment">a closure that enables enrichment on the generated event</param>
         /// <typeparam name="T">Type that implements <see cref="ISerializable"/></typeparam>
-        public virtual void Screen<T>(string title, T properties = default, string category = "") where T : ISerializable
+        public virtual void Screen<T>(string title, T properties = default, string category = "", Func<RawEvent, RawEvent> enrichment = default) where T : ISerializable
         {
             if (properties == null)
             {
-                Screen(title, category: category);
+                Screen(title, category: category, enrichment: enrichment);
             }
             else
             {
                 string json = JsonUtility.ToJson(properties);
-                Screen(title, JsonUtility.FromJson<JsonObject>(json), category);
+                Screen(title, JsonUtility.FromJson<JsonObject>(json), category, enrichment);
             }
         }
 
@@ -218,14 +227,15 @@ namespace Segment.Analytics
         /// <param name="title">A name for the page</param>
         /// <param name="properties">Properties to add extra information to this call</param>
         /// <param name="category">A category to describe the page</param>
-        public virtual void Page(string title, JsonObject properties = default, string category = "")
+        /// <param name="enrichment">a closure that enables enrichment on the generated event</param>
+        public virtual void Page(string title, JsonObject properties = default, string category = "", Func<RawEvent, RawEvent> enrichment = default)
         {
             if (properties == null)
             {
                 properties = new JsonObject();
             }
             var pageEvent = new PageEvent(category, title, properties);
-            Process(pageEvent);
+            Process(pageEvent, enrichment);
         }
 
         /// <summary>
@@ -236,17 +246,18 @@ namespace Segment.Analytics
         /// <param name="title">A name for the page</param>
         /// <param name="properties">Properties to add extra information to this call</param>
         /// <param name="category">A category to describe the page</param>
+        /// <param name="enrichment">a closure that enables enrichment on the generated event</param>
         /// <typeparam name="T">Type that implements <see cref="ISerializable"/></typeparam>
-        public virtual void Page<T>(string title, T properties = default, string category = "") where T : ISerializable
+        public virtual void Page<T>(string title, T properties = default, string category = "", Func<RawEvent, RawEvent> enrichment = default) where T : ISerializable
         {
             if (properties == null)
             {
-                Page(title, category: category);
+                Page(title, category: category, enrichment: enrichment);
             }
             else
             {
                 string json = JsonUtility.ToJson(properties);
-                Page(title, JsonUtility.FromJson<JsonObject>(json), category);
+                Page(title, JsonUtility.FromJson<JsonObject>(json), category, enrichment);
             }
         }
 
@@ -259,14 +270,15 @@ namespace Segment.Analytics
         /// </summary>
         /// <param name="groupId">Unique identifier which you recognize a group by in your own database</param>
         /// <param name="traits">Traits about the group</param>
-        public virtual void Group(string groupId, JsonObject traits = default)
+        /// <param name="enrichment">a closure that enables enrichment on the generated event</param>
+        public virtual void Group(string groupId, JsonObject traits = default, Func<RawEvent, RawEvent> enrichment = default)
         {
             if (traits == null)
             {
                 traits = new JsonObject();
             }
             var groupEvent = new GroupEvent(groupId, traits);
-            Process(groupEvent);
+            Process(groupEvent, enrichment);
         }
 
         /// <summary>
@@ -278,17 +290,18 @@ namespace Segment.Analytics
         /// </summary>
         /// <param name="groupId">Unique identifier which you recognize a group by in your own database</param>
         /// <param name="traits">Traits about the group</param>
+        /// <param name="enrichment">a closure that enables enrichment on the generated event</param>
         /// <typeparam name="T">Type that implements <see cref="ISerializable"/></typeparam>
-        public virtual void Group<T>(string groupId, T traits = default) where T : ISerializable
+        public virtual void Group<T>(string groupId, T traits = default, Func<RawEvent, RawEvent> enrichment = default) where T : ISerializable
         {
             if (traits == null)
             {
-                Group(groupId);
+                Group(groupId, enrichment: enrichment);
             }
             else
             {
                 string json = JsonUtility.ToJson(traits);
-                Group(groupId, JsonUtility.FromJson<JsonObject>(json));
+                Group(groupId, JsonUtility.FromJson<JsonObject>(json), enrichment);
             }
         }
 
@@ -301,7 +314,8 @@ namespace Segment.Analytics
         /// <param name="newId">The new ID you want to alias the existing ID to. The existing ID will be either
         /// the previousId if you have called identify, or the anonymous ID.
         /// </param>
-        public virtual void Alias(string newId)
+        /// <param name="enrichment">a closure that enables enrichment on the generated event</param>
+        public virtual void Alias(string newId, Func<RawEvent, RawEvent> enrichment = default)
         {
             var aliasEvent = new AliasEvent(newId, _userInfo._userId ?? _userInfo._anonymousId);
 
@@ -312,7 +326,7 @@ namespace Segment.Analytics
                 await Store.Dispatch<UserInfo.SetUserIdAction, UserInfo>(new UserInfo.SetUserIdAction(newId));
             });
 
-            Process(aliasEvent);
+            Process(aliasEvent, enrichment);
         }
     }
 }

--- a/Analytics-CSharp/Segment/Analytics/Timeline.cs
+++ b/Analytics-CSharp/Segment/Analytics/Timeline.cs
@@ -28,13 +28,18 @@ namespace Segment.Analytics
         /// initiate the event's lifecycle
         /// </summary>
         /// <param name="incomingEvent">event to be processed</param>
+        /// <param name="enrichment">a closure that enables enrichment on the generated event</param>
         /// <returns>event after processing</returns>
-        internal RawEvent Process(RawEvent incomingEvent)
+        internal RawEvent Process(RawEvent incomingEvent, Func<RawEvent, RawEvent> enrichment = default)
         {
             // Apply before and enrichment types first to start the timeline processing.
             RawEvent beforeResult = ApplyPlugins(PluginType.Before, incomingEvent);
             // Enrichment is like middleware, a chance to update the event across the board before going to destinations.
             RawEvent enrichmentResult = ApplyPlugins(PluginType.Enrichment, beforeResult);
+            if (enrichment != null)
+            {
+                enrichmentResult = enrichment(enrichmentResult);
+            }
 
             // Make sure not to update the events during this next cycle. Since each destination may want different
             // data than other destinations we don't want them conflicting and changing what a real result should be

--- a/Tests/AnalyticsTest.cs
+++ b/Tests/AnalyticsTest.cs
@@ -66,6 +66,19 @@ namespace Tests
         }
 
         [Fact]
+        public void TestSetAnonymousId()
+        {
+            string expected = "foo";
+            _storage.Setup(o => o.WritePrefs(StorageConstants.AnonymousId, expected)).Verifiable();
+            string anonIdOld = _analytics.AnonymousId();
+            _analytics.SetAnonymousId(expected);
+
+            string anonIdNew = _analytics.AnonymousId();
+            Assert.NotEqual(anonIdOld, anonIdNew);
+            Assert.Equal(expected, anonIdNew);
+        }
+
+        [Fact]
         public void TestUserId()
         {
             string expected = "test";

--- a/Tests/EventsTest.cs
+++ b/Tests/EventsTest.cs
@@ -348,7 +348,7 @@ namespace Tests
             _analytics.Add(_plugin.Object);
             _analytics.Identify(expectedUserId);
 
-            _analytics.Identify(null, null);
+            _analytics.Identify(userId:null, traits:null);
 
             var userIdEmpty = UserInfo.DefaultState(_analytics.Storage);
             Assert.Null(userIdEmpty._userId);

--- a/Tests/EventsTest.cs
+++ b/Tests/EventsTest.cs
@@ -17,6 +17,8 @@ namespace Tests
 
         private readonly Mock<StubEventPlugin> _plugin;
 
+        private readonly Mock<StubAfterEventPlugin> _afterPlugin;
+
         public EventsTest()
         {
             _settings = JsonUtility.FromJson<Settings?>(
@@ -31,6 +33,8 @@ namespace Tests
             {
                 CallBase = true
             };
+
+            _afterPlugin = new Mock<StubAfterEventPlugin> { CallBase = true };
 
             var config = new Configuration(
                 writeKey: "123",
@@ -123,6 +127,27 @@ namespace Tests
         }
 
         [Fact]
+        public void TestTrackEnrichment()
+        {
+            string expectedEvent = "foo";
+            string expectedAnonymousId = "bar";
+            var actual = new List<TrackEvent>();
+            _afterPlugin.Setup(o => o.Track(Capture.In(actual)));
+
+            _analytics.Add(_afterPlugin.Object);
+            _analytics.Track(expectedEvent, enrichment: @event =>
+            {
+                @event.AnonymousId = expectedAnonymousId;
+                return @event;
+            });
+
+            Assert.NotEmpty(actual);
+            Assert.True(actual[0].Properties.Count == 0);
+            Assert.Equal(expectedEvent, actual[0].Event);
+            Assert.Equal(expectedAnonymousId, actual[0].AnonymousId);
+        }
+
+        [Fact]
         public void TestIdentify()
         {
             var expected = new JsonObject
@@ -135,6 +160,35 @@ namespace Tests
 
             _analytics.Add(_plugin.Object);
             _analytics.Identify(expectedUserId, expected);
+
+            string actualUserId = _analytics.UserId();
+
+            Assert.NotEmpty(actual);
+            Assert.Equal(expected, actual[0].Traits);
+            Assert.Equal(expectedUserId, actualUserId);
+        }
+
+        [Fact]
+        public void TestIdentifyEnrichment()
+        {
+            var expected = new JsonObject
+            {
+                ["foo"] = "bar"
+            };
+            string expectedUserId = "newUserId";
+            var actual = new List<IdentifyEvent>();
+            _afterPlugin.Setup(o => o.Identify(Capture.In(actual)));
+
+            _analytics.Add(_afterPlugin.Object);
+            _analytics.Identify(expectedUserId, expected, @event =>
+            {
+                if (@event is IdentifyEvent identifyEvent)
+                {
+                    identifyEvent.Traits["foo"] = "baz";
+                }
+
+                return @event;
+            });
 
             string actualUserId = _analytics.UserId();
 
@@ -322,6 +376,35 @@ namespace Tests
         }
 
         [Fact]
+        public void TestScreenEnrichment()
+        {
+            var expected = new JsonObject
+            {
+                ["foo"] = "bar"
+            };
+            string expectedTitle = "foo";
+            string expectedCategory = "bar";
+            var actual = new List<ScreenEvent>();
+            _afterPlugin.Setup(o => o.Screen(Capture.In(actual)));
+
+            _analytics.Add(_afterPlugin.Object);
+            _analytics.Screen(expectedTitle, expected, expectedCategory, @event =>
+            {
+                if (@event is ScreenEvent screenEvent)
+                {
+                    screenEvent.Properties["foo"] = "baz";
+                }
+
+                return @event;
+            });
+
+            Assert.NotEmpty(actual);
+            Assert.Equal(expected, actual[0].Properties);
+            Assert.Equal(expectedTitle, actual[0].Name);
+            Assert.Equal(expectedCategory, actual[0].Category);
+        }
+
+        [Fact]
         public void TestScreenWithNulls()
         {
             var actual = new List<ScreenEvent>();
@@ -383,6 +466,36 @@ namespace Tests
 
             _analytics.Add(_plugin.Object);
             _analytics.Page(expectedTitle, expected, expectedCategory);
+
+            Assert.NotEmpty(actual);
+            Assert.Equal(expected, actual[0].Properties);
+            Assert.Equal(expectedTitle, actual[0].Name);
+            Assert.Equal(expectedCategory, actual[0].Category);
+            Assert.Equal("page", actual[0].Type);
+        }
+
+        [Fact]
+        public void TestPageEnrichment()
+        {
+            var expected = new JsonObject
+            {
+                ["foo"] = "bar"
+            };
+            string expectedTitle = "foo";
+            string expectedCategory = "bar";
+            var actual = new List<PageEvent>();
+            _afterPlugin.Setup(o => o.Page(Capture.In(actual)));
+
+            _analytics.Add(_afterPlugin.Object);
+            _analytics.Page(expectedTitle, expected, expectedCategory, @event =>
+            {
+                if (@event is PageEvent pageEvent)
+                {
+                    pageEvent.Properties["foo"] = "baz";
+                }
+
+                return @event;
+            });
 
             Assert.NotEmpty(actual);
             Assert.Equal(expected, actual[0].Properties);
@@ -462,6 +575,33 @@ namespace Tests
         }
 
         [Fact]
+        public void TestGroupEnrichment()
+        {
+            var expected = new JsonObject
+            {
+                ["foo"] = "bar"
+            };
+            string expectedGroupId = "foo";
+            var actual = new List<GroupEvent>();
+            _afterPlugin.Setup(o => o.Group(Capture.In(actual)));
+
+            _analytics.Add(_afterPlugin.Object);
+            _analytics.Group(expectedGroupId, expected, @event =>
+            {
+                if (@event is GroupEvent groupEvent)
+                {
+                    groupEvent.Traits["foo"] = "baz";
+                }
+
+                return @event;
+            });
+
+            Assert.NotEmpty(actual);
+            Assert.Equal(expected, actual[0].Traits);
+            Assert.Equal(expectedGroupId, actual[0].GroupId);
+        }
+
+        [Fact]
         public void TestGroupNoProperties()
         {
             string expectedGroupId = "foo";
@@ -522,6 +662,32 @@ namespace Tests
             Assert.NotEmpty(actual);
             Assert.Equal(expectedPrevious, actual[0].PreviousId);
             Assert.Equal(expected, actual[0].UserId);
+        }
+
+        [Fact]
+        public void TestAliasEnrichment()
+        {
+            string expectedPrevious = "foo";
+            string expected = "bar";
+            var actual = new List<AliasEvent>();
+            _afterPlugin.Setup(o => o.Alias(Capture.In(actual)));
+
+            _analytics.Add(_afterPlugin.Object);
+            _analytics.Identify(expectedPrevious);
+            _analytics.Alias(expected, @event =>
+            {
+                if (@event is AliasEvent aliasEvent)
+                {
+                    aliasEvent.AnonymousId = "test";
+                }
+
+                return @event;
+            });
+
+            Assert.NotEmpty(actual);
+            Assert.Equal(expectedPrevious, actual[0].PreviousId);
+            Assert.Equal(expected, actual[0].UserId);
+            Assert.Equal("test", actual[0].AnonymousId);
         }
     }
 }


### PR DESCRIPTION
* enables event enrichment at per event call basis.
* add `analytics.SetAnonymousId` to update the cached anonymousId. 