### PR TITLE
Fix issue where user-supplied enrichments were lost during the startu…

### DIFF
--- a/Analytics-CSharp/Segment/Analytics/Analytics.cs
+++ b/Analytics-CSharp/Segment/Analytics/Analytics.cs
@@ -86,10 +86,10 @@ namespace Segment.Analytics
         {
             if (!Enable) return;
 
-            incomingEvent.ApplyRawEventData(_userInfo);
+            incomingEvent.ApplyRawEventData(_userInfo, enrichment);
             AnalyticsScope.Launch(AnalyticsDispatcher, () =>
             {
-                Timeline.Process(incomingEvent, enrichment);
+                Timeline.Process(incomingEvent);
             });
         }
 

--- a/Analytics-CSharp/Segment/Analytics/Plugins/StartupQueue.cs
+++ b/Analytics-CSharp/Segment/Analytics/Plugins/StartupQueue.cs
@@ -58,7 +58,7 @@ namespace Segment.Analytics.Plugins
             {
                 if (_queuedEvents.TryDequeue(out RawEvent e))
                 {
-                    Analytics.Process(e);
+                    Analytics.Process(e, e.Enrichment);
                 }
             }
         }

--- a/Analytics-CSharp/Segment/Analytics/Timeline.cs
+++ b/Analytics-CSharp/Segment/Analytics/Timeline.cs
@@ -30,15 +30,15 @@ namespace Segment.Analytics
         /// <param name="incomingEvent">event to be processed</param>
         /// <param name="enrichment">a closure that enables enrichment on the generated event</param>
         /// <returns>event after processing</returns>
-        internal RawEvent Process(RawEvent incomingEvent, Func<RawEvent, RawEvent> enrichment = default)
+        internal RawEvent Process(RawEvent incomingEvent)
         {
             // Apply before and enrichment types first to start the timeline processing.
             RawEvent beforeResult = ApplyPlugins(PluginType.Before, incomingEvent);
             // Enrichment is like middleware, a chance to update the event across the board before going to destinations.
             RawEvent enrichmentResult = ApplyPlugins(PluginType.Enrichment, beforeResult);
-            if (enrichment != null)
+            if (enrichmentResult.Enrichment != null)
             {
-                enrichmentResult = enrichment(enrichmentResult);
+                enrichmentResult = enrichmentResult.Enrichment(enrichmentResult);
             }
 
             // Make sure not to update the events during this next cycle. Since each destination may want different

--- a/Analytics-CSharp/Segment/Analytics/Timeline.cs
+++ b/Analytics-CSharp/Segment/Analytics/Timeline.cs
@@ -36,7 +36,7 @@ namespace Segment.Analytics
             RawEvent beforeResult = ApplyPlugins(PluginType.Before, incomingEvent);
             // Enrichment is like middleware, a chance to update the event across the board before going to destinations.
             RawEvent enrichmentResult = ApplyPlugins(PluginType.Enrichment, beforeResult);
-            if (enrichmentResult.Enrichment != null)
+            if (enrichmentResult != null && enrichmentResult.Enrichment != null)
             {
                 enrichmentResult = enrichmentResult.Enrichment(enrichmentResult);
             }

--- a/Analytics-CSharp/Segment/Analytics/Types.cs
+++ b/Analytics-CSharp/Segment/Analytics/Types.cs
@@ -18,6 +18,8 @@ namespace Segment.Analytics
         public virtual string UserId { get; set; }
         public virtual string Timestamp { get; set; }
 
+        public Func<RawEvent, RawEvent> Enrichment { get; set; }
+
         // JSON types
         public JsonObject Context { get; set; }
         public JsonObject Integrations { get; set; }
@@ -36,8 +38,9 @@ namespace Segment.Analytics
             Integrations = rawEvent.Integrations;
         }
 
-        internal void ApplyRawEventData(UserInfo userInfo)
+        internal void ApplyRawEventData(UserInfo userInfo, Func<RawEvent, RawEvent> enrichment)
         {
+            Enrichment = enrichment;
             MessageId = Guid.NewGuid().ToString();
             Context = new JsonObject();
             Timestamp = DateTime.UtcNow.ToString("o"); // iso8601

--- a/Tests/EventsTest.cs
+++ b/Tests/EventsTest.cs
@@ -921,11 +921,9 @@ namespace Tests
         [Fact]
         public void TestAliasEnrichment()
         {
-            string expectedPrevious = "foo";
             string expected = "bar";
 
             _analytics.Add(_afterPlugin.Object);
-            _analytics.Identify(expectedPrevious);
             _analytics.Alias(expected, @event =>
             {
                 if (@event is AliasEvent aliasEvent)
@@ -945,7 +943,6 @@ namespace Tests
             Assert.NotEmpty(_actual);
             var actual = _actual.Find(o => o is AliasEvent) as AliasEvent;
             Debug.Assert(actual != null, nameof(actual) + " != null");
-            Assert.Equal(expectedPrevious, actual.PreviousId);
             Assert.Equal(expected, actual.UserId);
             Assert.Equal("test", actual.AnonymousId);
         }


### PR DESCRIPTION
* made the enrichment closure a property of event so it is not lost during startup queue replay